### PR TITLE
Add config file

### DIFF
--- a/.gitlab-cli-config.yml
+++ b/.gitlab-cli-config.yml
@@ -1,0 +1,3 @@
+repo1:
+  baseUrl: https://gitlabci.example.com
+  accessToken: exampleToken

--- a/.gitlab-cli-config.yml
+++ b/.gitlab-cli-config.yml
@@ -1,3 +1,2 @@
-repo1:
-  baseUrl: https://gitlabci.example.com
-  accessToken: exampleToken
+baseUrl: https://gitlabci.example.com
+privateToken: exampleToken

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ gitlab-cli provides a simple interface to interact with Gitlab servers. It has t
 
 Gitlab authentication is done using [Person Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html). To generate a new token, go to "Gitlab > User Settings > Access Token".
 
+
+### Config file
+
+The Gitlab base url and access token can be stored in a config file. The default location of the config file is `$HOME/.gitlab-cli-config.yml`.
+A Sample config file looks like this:
+
+```yaml
+baseUrl: https://gitlabci.example.com
+privateToken: 90we48534tgDFf345
+```
+
 ## Interactive mode
 
 In the interactive mode, gitlab-cli asks user the actions and parameters for each action in an interactive way.
@@ -37,7 +48,16 @@ In the command mode, user should enter the action and all the necessary argument
 ## TODO
 
 - Other actions can be added. Feel free to create pull requests or issues.
-- Save the gitlab server info (base url and access token) in a config file.
+- Introduce profiles in the config file and receive the active profile as an argument. Example:
+```yaml
+server1:
+    baseUrl: https://gitlabci.server1.com
+    privateToken: 90we48534tgDFf345
+server2:
+    baseUrl: https://gitlabci.server2.com
+    privateToken: 24r58534t2gfg4671
+```
+- Add a new argument to override the location of the config file.
 
 ## Dev it!
 

--- a/README.md
+++ b/README.md
@@ -82,4 +82,5 @@ or
 
 - [promptui](https://github.com/manifoldco/promptui)
 - [cobra](https://github.com/spf13/cobra)
+- [viper](https://github.com/spf13/viper)
 - [Testify](https://github.com/stretchr/testify)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/EXXETA/gitlab-cli/config"
 	"github.com/EXXETA/gitlab-cli/interactive"
 	"github.com/EXXETA/gitlab-cli/service"
 	"github.com/spf13/cobra"
@@ -11,6 +12,9 @@ import (
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&service.GitlabBaseURL, "url", "u", "", "GitLab server base url")
 	rootCmd.PersistentFlags().StringVarP(&service.PrivateToken, "token", "t", "", "Personal access token to authenticate against GitLab")
+
+	// initialize the config file
+	config.InitConfig("")
 }
 
 // rootCmd defines the root command of the gitlabacli command mode

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&service.GitlabBaseURL, "url", "u", "", "GitLab server base url")
 	rootCmd.PersistentFlags().StringVarP(&service.PrivateToken, "token", "t", "", "Personal access token to authenticate against GitLab")
 
-	// initialize the config file
+	// initialize the config file and read server settings
 	config.InitConfig("")
+	service.GitlabBaseURL = config.GetConfigValue("baseUrl")
+	service.PrivateToken = config.GetConfigValue("privateToken")
 }
 
 // rootCmd defines the root command of the gitlabacli command mode

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/spf13/viper"
 )
 
@@ -31,4 +32,9 @@ func InitConfig(configFileFromFlag string) {
 	} else {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+// GetConfigValue returns the value of a config parameter
+func GetConfigValue(parameterName string) string {
+	return viper.GetString(parameterName)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+	"github.com/spf13/viper"
+)
+
+var (
+	// default path of the config file
+	defaultConfigFilePath = "$HOME"
+
+	// default config file name
+	defaultConfigFileName = ".gitlab-cli-config"
+)
+
+// InitConfig initializes the config file
+func InitConfig(configFileFromFlag string) {
+
+	// if the config file was set in a flag
+	if configFileFromFlag != "" {
+		viper.SetConfigFile(configFileFromFlag)
+	}
+
+	// set the default config file info
+	viper.SetConfigName(defaultConfigFileName)
+	viper.AddConfigPath(defaultConfigFilePath)
+
+	// read the config file
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Println("Error wile reading the config file.", err)
+	} else {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/manifoldco/promptui v0.3.2
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
 )

--- a/interactive/root.go
+++ b/interactive/root.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	rootActions         = []string{"projects", "releases", "exit"}
-	exxetaGitlabBaseURL = "https://gitlabci.exxeta.com"
+	rootActions = []string{"projects", "releases", "exit"}
 )
 
 // Execute main method of the interactive mode

--- a/interactive/root.go
+++ b/interactive/root.go
@@ -17,18 +17,21 @@ var (
 // Execute main method of the interactive mode
 func Execute() {
 
-	fmt.Println(service.GitlabBaseURL)
 	// gitlab base url
-	gitlabURL := executeNotMaskedPrompt("Please enter your GitLab base url", exxetaGitlabBaseURL)
-	if gitlabURL != "" {
-		// remove the ending "/" from the URL if it has any
-		service.GitlabBaseURL = strings.TrimSuffix(gitlabURL, "/")
+	if service.GitlabBaseURL == "" {
+		gitlabURL := executeNotMaskedPrompt("Please enter your GitLab base url", "")
+		if gitlabURL != "" {
+			// remove the ending "/" from the URL if it has any
+			service.GitlabBaseURL = strings.TrimSuffix(gitlabURL, "/")
+		}
 	}
 
 	// person access token
-	personalToken := executeMaskedPrompt("Please enter your GitLab personal access token (You can find it under 'GitLab > User Settings > Access Tokens')", "")
-	if personalToken != "" {
-		service.PrivateToken = personalToken
+	if service.PrivateToken == "" {
+		personalToken := executeMaskedPrompt("Please enter your GitLab personal access token (You can find it under 'GitLab > User Settings > Access Tokens')", "")
+		if personalToken != "" {
+			service.PrivateToken = personalToken
+		}
 	}
 
 	// access the "/version" endpoint to make sure the url and the token are valid


### PR DESCRIPTION
Config file is used to save gitlab info (base url and access token) to avoid enter it every time starting the cli.

- initialize config file using "Viper" library
- read the base url and access token from the default config file.
- don't ask fo base url and access token in the interactive mode when these values are read from config file.